### PR TITLE
Double-underscore cannot be used in HTML tag attributes

### DIFF
--- a/src/modules/PostCalendar/templates/event/filtercats.tpl
+++ b/src/modules/PostCalendar/templates/event/filtercats.tpl
@@ -13,7 +13,7 @@
         all=1
         allText=$allText
         allValue=0}
-    <a href='#' id='postcalendar_events___CATEGORIES____{$property}__open' __title='Select multiple categories'>
+    <a href='#' id='postcalendar_events___CATEGORIES____{$property}__open' title='{gt text="Select multiple categories"}'>
         {img modname="core" src="edit_add.png" set="icons/extrasmall" __alt="Select Multiple" __title="Select Multiple"}
     </a>
     <script type="text/javascript">


### PR DESCRIPTION
Double-underscore cannot be used in HTML tag attributes as a shortcut for gettext. That only works for template function attributes.

Replaced `__title='...titletext...'` with `title='{gt text="...titletext..."}'`.
