### PR TITLE
Fixed fatal error :-)

### DIFF
--- a/lib/PostCalendar/Api/Event.php
+++ b/lib/PostCalendar/Api/Event.php
@@ -61,7 +61,7 @@ class PostCalendar_Api_Event extends Zikula_AbstractApi
     {
         $startDate   = isset($args['start'])       ? $args['start']       : new DateTime();
         $endDate     = isset($args['end'])         ? $args['end']         : null;
-        $filtercats  = isset($args['filtercats'])  ? $args['filtercats']  : '';
+        $filtercats  = isset($args['filtercats'])  ? $args['filtercats']  : array();
         $userFilter  = isset($args['userfilter'])  ? $args['userfilter'] : '';
         $searchDql   = isset($args['s_keywords'])  ? $args['s_keywords']  : ''; // search WHERE dql
         $searchstart = isset($args['searchstart']) ? $args['searchstart'] : '';


### PR DESCRIPTION
`PostCalendar_Entity_Repository_CalendarEventRepository::getEventCollection()` requires an array and not a string. This produced a fatal error:

_Catchable fatal error: Argument 6 passed to PostCalendar_Entity_Repository_CalendarEventRepository::getEventCollection() must be of the type array, string given, called in src/modules/PostCalendar/lib/PostCalendar/Api/Event.php on line 108 and defined in src/modules/PostCalendar/lib/PostCalendar/Entity/Repository/CalendarEventRepository.php on line 82_
