### PR TITLE
Added selectedCategories to render of CalendarView_Year

### DIFF
--- a/lib/PostCalendar/CalendarView/Year.php
+++ b/lib/PostCalendar/CalendarView/Year.php
@@ -147,6 +147,7 @@ class PostCalendar_CalendarView_Year extends PostCalendar_CalendarView_AbstractD
                     ->assign('monthNames', explode(" ", $this->__('January February March April May June July August September October November December')))
                     ->assign('graph', $this->dateGraph)
                     ->assign('eventsByDate', $eventsByDate)
+                    ->assign('selectedCategories', $this->selectedCategories)
                     ->assign('requestedDate', $this->requestedDate->format('Y-m-d'));
         }
         return $this->view->fetch($this->template);


### PR DESCRIPTION
In PC 6 this property was rendered in the template, which can then be used to do styling of the calendar based on the selected categories.
